### PR TITLE
Initial OC commit

### DIFF
--- a/napalm_cumulus/openconfig_mappings.yaml
+++ b/napalm_cumulus/openconfig_mappings.yaml
@@ -1,0 +1,66 @@
+---
+interfaces:
+    interface:
+        _block_capture: "(?P<block>interface (?P<key>(eth|swp|lo|vlan|bridge|bond)\\d*)\n(?:.|\n)*?^$)"
+        name:
+            _search: "interface (?P<value>(eth|swp|lo|vlan|bridge|bond).*)"
+            _type: py23_compat.text_type
+        hold_time:
+            config:
+                down:
+                    _search: "napalm: not implemented"
+                    _type: int
+                    _default: 0
+                up:
+                    _search: "napalm: not implemented"
+                    _type: int
+                    _default: 0
+        config:
+            name:
+                _search: "interface (?P<value>(eth|swp|lo|vlan|bridge|bond).*)"
+                _type: py23_compat.text_type
+            type_:
+                _search: "interface (?P<value>(eth|swp|lo|vlan|bridge|bond)).*"
+                _type: mapping
+                _map:
+                    eth: napalm_yang.ianaift.Ethernetcsmacd
+                    swp: napalm_yang.ianaift.Ethernetcsmacd
+                    lo: napalm_yang.ianaift.Softwareloopback
+                    vlan: napalm_yang.ianaift.L2Vlan
+                    bridge: napalm_yang.ianaift.Ethernetcsmacd
+                    bond: napalm_yang.interfaces.Ieee8023Adlag
+            enabled:
+                _search: "UP"
+                _type: boolean
+                _default: False
+            description:
+                _search: "alias (?P<value>.*)"
+                _type: py23_compat.text_type
+                _default: ""
+            mtu:
+                _search: "mtu (?P<value>(?!(?:65536))\\d+)"
+                _type: int
+                _default: 1500
+        subinterfaces:
+            subinterface:
+                _block_capture: "(?P<block>interface (?P<key>{parent_key}\\.\\d+)\\n(?:.|\\n)*?^$)"
+                index:
+                    _search: "napalm: not implemented"
+                    _type: int
+                    _default: 0
+                config:
+                    index:
+                        _search: "napalm: not implemented"
+                        _type: int
+                        _default: 0
+                    name:
+                        _search: "interface (?P<value>(eth|swp|lo|vlan|bridge|bond).*)"
+                        _type: py23_compat.text_type
+                    enabled:
+                        _search: "UP"
+                        _type: boolean
+                        _default: False
+                    description:
+                        _search: "alias (?P<value>.*)"
+                        _type: py23_compat.text_type
+                        _default: ""

--- a/oc_test.py
+++ b/oc_test.py
@@ -1,0 +1,47 @@
+from napalm_cumulus.cumulus import CumulusDriver
+
+
+def print_data(name, data, indentation=""):
+    meta = data["_meta"]
+    mode = "rw" if meta["config"] else "ro"
+    key = "* [{}]".format(meta.get("key", "")) if meta.get("key", "") else ""
+    print("{}+-- {} {}{}".format(indentation, mode, name, key))
+    indentation = indentation + "|  "
+
+    for attr, attr_data in data.items():
+        if attr == "_meta":
+            continue
+        elif attr == "list":
+            for e, d in attr_data.items():
+                print_data(e, d, indentation)
+        elif "value" in attr_data.keys():
+            sm = attr_data["_meta"]
+
+            if sm["type"] == "Enumeration":
+                try:
+                    value = "{} ({})".format(attr_data["value"], attr_data["enum_value"])
+                except:
+                    raise Exception(attr_data)
+            else:
+                value = attr_data["value"]
+
+            mandatory = "" if sm["mandatory"] else "?"
+            body = "{}+-- {} {}{}".format(indentation, mode, attr, mandatory)
+            spacing = " " * (60 - len(body))
+            print("{}{}{}".format(body, spacing, value))
+        else:
+            print_data(attr, attr_data, indentation)
+
+
+cumulus_config = {
+    "hostname": "127.0.0.1",
+    "username": "cumulus",
+    "password": "CumulusLinux!",
+    "optional_args": {"port": 2222, "sudo_pwd": "CumulusLinux!"},
+}
+
+
+d = CumulusDriver(**cumulus_config)
+d.open()
+d.oc_populate_interfaces()
+print_data("interfaces", d.interfaces.data_representation())


### PR DESCRIPTION
Mirroring what @dbarrosop is doing on [napalm-eos](https://github.com/napalm-automation/napalm-eos/pull/123), this is a first attempt for OC support on cumulus driver.

I haven't completed the translation from OC to native configuration yet as it needs more considerations due to the nature of NCLU and the underlying linux OS.

The `oc_test.py` script returns this:
```
+-- rw interfaces
|  +-- rw interface* [name]
|  |  +-- rw bridge* [name]
|  |  |  +-- rw subinterfaces
|  |  |  |  +-- rw subinterface* [index]
|  |  |  +-- rw config
|  |  |  |  +-- rw enabled?                                 True
|  |  |  |  +-- rw name?                                    bridge
|  |  |  |  +-- rw type_                                    ethernetCsmacd
|  |  |  |  +-- rw mtu?                                     1500
|  |  |  |  +-- rw description?                             
|  |  |  +-- ro state
|  |  |  |  +-- ro type_                                    None
|  |  |  |  +-- ro admin_status                             None (None)
|  |  |  |  +-- ro oper_status                              None (None)
|  |  |  +-- rw hold_time
|  |  |  |  +-- rw config
|  |  |  |  |  +-- rw down?                                 0
|  |  |  |  |  +-- rw up?                                   0
|  |  |  +-- rw name?                                       bridge
|  |  +-- rw vlan10* [name]
|  |  |  +-- rw subinterfaces
|  |  |  |  +-- rw subinterface* [index]
|  |  |  +-- rw config
|  |  |  |  +-- rw enabled?                                 True
|  |  |  |  +-- rw name?                                    vlan10
|  |  |  |  +-- rw type_                                    l2vlan
|  |  |  |  +-- rw mtu?                                     1500
|  |  |  |  +-- rw description?                             
|  |  |  +-- ro state
|  |  |  |  +-- ro type_                                    None
|  |  |  |  +-- ro admin_status                             None (None)
|  |  |  |  +-- ro oper_status                              None (None)
|  |  |  +-- rw hold_time
|  |  |  |  +-- rw config
|  |  |  |  |  +-- rw down?                                 0
|  |  |  |  |  +-- rw up?                                   0
|  |  |  +-- rw name?                                       vlan10
|  |  +-- rw lo* [name]
|  |  |  +-- rw subinterfaces
|  |  |  |  +-- rw subinterface* [index]
|  |  |  +-- rw config
|  |  |  |  +-- rw enabled?                                 True
|  |  |  |  +-- rw name?                                    lo
|  |  |  |  +-- rw type_                                    softwareLoopback
|  |  |  |  +-- rw mtu?                                     1500
|  |  |  |  +-- rw description?                             test description
|  |  |  +-- ro state
|  |  |  |  +-- ro type_                                    None
|  |  |  |  +-- ro admin_status                             None (None)
|  |  |  |  +-- ro oper_status                              None (None)
|  |  |  +-- rw hold_time
|  |  |  |  +-- rw config
|  |  |  |  |  +-- rw down?                                 0
|  |  |  |  |  +-- rw up?                                   0
|  |  |  +-- rw name?                                       lo
|  |  +-- rw swp2* [name]
|  |  |  +-- rw subinterfaces
|  |  |  |  +-- rw subinterface* [index]
|  |  |  +-- rw config
|  |  |  |  +-- rw enabled?                                 True
|  |  |  |  +-- rw name?                                    swp2
|  |  |  |  +-- rw type_                                    ethernetCsmacd
|  |  |  |  +-- rw mtu?                                     1500
|  |  |  |  +-- rw description?                             
|  |  |  +-- ro state
|  |  |  |  +-- ro type_                                    None
|  |  |  |  +-- ro admin_status                             None (None)
|  |  |  |  +-- ro oper_status                              None (None)
|  |  |  +-- rw hold_time
|  |  |  |  +-- rw config
|  |  |  |  |  +-- rw down?                                 0
|  |  |  |  |  +-- rw up?                                   0
|  |  |  +-- rw name?                                       swp2
|  |  +-- rw swp1* [name]
|  |  |  +-- rw subinterfaces
|  |  |  |  +-- rw subinterface* [index]
|  |  |  |  |  +-- rw swp1.100* [index]
|  |  |  |  |  |  +-- rw index?                             0
|  |  |  |  |  |  +-- ro state
|  |  |  |  |  |  |  +-- ro admin_status                    None (None)
|  |  |  |  |  |  |  +-- ro oper_status                     None (None)
|  |  |  |  |  |  +-- rw config
|  |  |  |  |  |  |  +-- rw index?                          0
|  |  |  |  |  |  |  +-- rw enabled?                        True
|  |  |  |  |  |  |  +-- rw description?                    
|  |  |  |  |  |  |  +-- rw name?                           swp1.100
|  |  |  +-- rw config
|  |  |  |  +-- rw enabled?                                 True
|  |  |  |  +-- rw name?                                    swp1
|  |  |  |  +-- rw type_                                    ethernetCsmacd
|  |  |  |  +-- rw mtu?                                     1500
|  |  |  |  +-- rw description?                             
|  |  |  +-- ro state
|  |  |  |  +-- ro type_                                    None
|  |  |  |  +-- ro admin_status                             None (None)
|  |  |  |  +-- ro oper_status                              None (None)
|  |  |  +-- rw hold_time
|  |  |  |  +-- rw config
|  |  |  |  |  +-- rw down?                                 0
|  |  |  |  |  +-- rw up?                                   0
|  |  |  +-- rw name?                                       swp1
|  |  +-- rw eth0* [name]
|  |  |  +-- rw subinterfaces
|  |  |  |  +-- rw subinterface* [index]
|  |  |  |  |  +-- rw eth0.1* [index]
|  |  |  |  |  |  +-- rw index?                             0
|  |  |  |  |  |  +-- ro state
|  |  |  |  |  |  |  +-- ro admin_status                    None (None)
|  |  |  |  |  |  |  +-- ro oper_status                     None (None)
|  |  |  |  |  |  +-- rw config
|  |  |  |  |  |  |  +-- rw index?                          0
|  |  |  |  |  |  |  +-- rw enabled?                        True
|  |  |  |  |  |  |  +-- rw description?                    
|  |  |  |  |  |  |  +-- rw name?                           eth0.1
|  |  |  +-- rw config
|  |  |  |  +-- rw enabled?                                 True
|  |  |  |  +-- rw name?                                    eth0
|  |  |  |  +-- rw type_                                    ethernetCsmacd
|  |  |  |  +-- rw mtu?                                     1500
|  |  |  |  +-- rw description?                             another test description
|  |  |  +-- ro state
|  |  |  |  +-- ro type_                                    None
|  |  |  |  +-- ro admin_status                             None (None)
|  |  |  |  +-- ro oper_status                              None (None)
|  |  |  +-- rw hold_time
|  |  |  |  +-- rw config
|  |  |  |  |  +-- rw down?                                 0
|  |  |  |  |  +-- rw up?                                   0
|  |  |  +-- rw name?                                       eth0
```