### PR TITLE
Dbarrosop/ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+.idea
+.DS_Store
+
+env
+*.swp
+
+test/unit/test_devices.py
+
+report.json
+
+tags
+.vagrant

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+ifndef NAPALM_TEST_MOCK
+	mock:='1'
+endif
+
+export NAPALM_TEST_MOCK=$(mock)
+export NAPALM_HOSTNAME=127.0.0.1
+export NAPALM_USERNAME=vagrant
+export NAPALM_PASSWORD=vagrant
+export NAPALM_OPTIONAL_ARGS={"port": 65022}
+
+start_vm:
+	# vagrant plugin install vagrant-cumulus
+	vagrant up
+
+stop_vm:
+	vagrant destroy
+
+tests:
+	py.test
+
+test_vm: NAPALM_TEST_MOCK=0
+test_vm: start_vm tests
+	py.test test/unit/TestCumulusDriver.py

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,7 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "CumulusCommunity/cumulus-vx"
+  config.vm.box_version = "3.2.0"
+
+  config.vm.network :forwarded_port, guest: 22, host: 65022, id: 'ssh'
+  config.ssh.port = 65022
+end

--- a/napalm_cumulus/cumulus.py
+++ b/napalm_cumulus/cumulus.py
@@ -33,7 +33,7 @@ from napalm_base.base import NetworkDriver
 from napalm_base.exceptions import (
     ConnectionException,
     MergeConfigException,
-    ReplaceConfigException
+    #  ReplaceConfigException
     )
 
 

--- a/test/unit/TestCumulusDriver.py
+++ b/test/unit/TestCumulusDriver.py
@@ -31,10 +31,10 @@ class TestConfigCumulusDriver(unittest.TestCase, TestConfigNetworkDriver):
         password = 'vagrant'
         cls.vendor = 'cumulus'
 
-        optional_args = {'port': 12443, }
+        optional_args = {'port': 65022, }
         cls.device = cumulus.CumulusDriver(hostname, username, password, timeout=60,
-                                             optional_args=optional_args)
+                                           optional_args=optional_args)
         cls.device.open()
 
-        cls.device.load_replace_candidate(filename='%s/initial.conf' % cls.vendor)
+        cls.device.load_merge_candidate(filename='%s/initial.conf' % cls.vendor)
         cls.device.commit_config()

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -35,7 +35,12 @@ class PatchedCumulusDriver(cumulus.CumulusDriver):
         super().__init__(hostname, username, password, timeout, optional_args)
 
         self.patched_attrs = ['device']
+
+    def open(self):
         self.device = FakeCumulusDevice()
+
+    def is_alive(self):
+        return {'is_alive': True}
 
 
 class FakeCumulusDevice(BaseTestDouble):
@@ -55,3 +60,6 @@ class FakeCumulusDevice(BaseTestDouble):
                 result.append({'output': self.read_txt_file(full_path)})
 
         return result
+
+    def disconnect(self):
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ deps =
     -rrequirements-dev.txt
 
 commands=
-    py.test
+    make tests


### PR DESCRIPTION
@GGabriele @ktbyers @mirceaulinic I have done some new stuff here trying to standardize how we do tests locally with VMs (so it's easier to test big changes). The idea is to have a Makefile with an agreed sets of targets to:

- start a vm, fully configured and ready for testing
- stop the vm
- run the tests against the mocked data
- run the same tests against the VM
- run the configuration tests

This example is missing how to configure the VM as that part is missing in this repo.

Thoughts?